### PR TITLE
Update base version constraint to <4.10

### DIFF
--- a/bytestring-arbitrary.cabal
+++ b/bytestring-arbitrary.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     Data.ByteString.Arbitrary
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.6 && <4.9
+  build-depends:       base >=4.6 && <4.10
                      , bytestring >=0.10 && <0.12
                      , cryptohash
                      , QuickCheck
@@ -32,7 +32,7 @@ benchmark benchmark-all
   type:                exitcode-stdio-1.0
   hs-source-dirs:      benches
   main-is:             bench.hs
-  build-depends:       base >=4.6 && <4.9
+  build-depends:       base >=4.6 && <4.10
                      , bytestring >=0.10 && <0.12
                      , cryptohash
                      , QuickCheck


### PR DESCRIPTION
bytestring-arbitrary works fine with ghc 8.0.1 and base 4.9.
