### PR TITLE
Update version constraint on base to <4.11

### DIFF
--- a/bytestring-arbitrary.cabal
+++ b/bytestring-arbitrary.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     Data.ByteString.Arbitrary
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.6 && <4.10
+  build-depends:       base >=4.6 && <4.11
                      , bytestring >=0.10 && <0.12
                      , cryptohash
                      , QuickCheck
@@ -32,7 +32,7 @@ benchmark benchmark-all
   type:                exitcode-stdio-1.0
   hs-source-dirs:      benches
   main-is:             bench.hs
-  build-depends:       base >=4.6 && <4.10
+  build-depends:       base >=4.6 && <4.11
                      , bytestring >=0.10 && <0.12
                      , cryptohash
                      , QuickCheck
@@ -52,4 +52,3 @@ Test-Suite test-all
                      , bytestring-arbitrary
   default-language:    Haskell2010
   ghc-options:         -Wall
-


### PR DESCRIPTION
bytestring-arbitrary works with ghc 8.2.2 and base 4.10.